### PR TITLE
feat: add PrivacyScreen, LicenseScreen and Impressum to settings

### DIFF
--- a/assets/fonts/Inter-license.txt
+++ b/assets/fonts/Inter-license.txt
@@ -1,0 +1,92 @@
+Copyright (c) 2016 The Inter Project Authors (https://github.com/rsms/inter)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION AND CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -18,6 +20,11 @@ import 'security/first_run_reset.dart';
 import 'db/sqlcipher_setup.dart';
 
 Future<void> main() async {
+  LicenseRegistry.addLicense(() async* {
+    final text = await rootBundle.loadString('assets/fonts/Inter-license.txt');
+    yield LicenseEntryWithLineBreaks(['Inter'], text);
+  });
+
   WidgetsFlutterBinding.ensureInitialized();
 
   await setupSqlCipher();

--- a/lib/screens/imprint_screen.dart
+++ b/lib/screens/imprint_screen.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../widgets/app_header.dart';
+
+class ImprintScreen extends StatelessWidget {
+  const ImprintScreen({super.key});
+
+  Future<void> _launchEmail(String email) async {
+    final uri = Uri(scheme: 'mailto', path: email);
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  Future<void> _launchTel(String phone) async {
+    final cleaned = phone.replaceAll(' ', '');
+    final uri = Uri(scheme: 'tel', path: cleaned);
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const AppHeader(title: 'Impressum'),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _heading('Anbieter'),
+            const Text(
+              'Deutscher Fachverband für Psychosoziale Notfallversorgung (DF-PSNV) e.V.\n'
+              'P.-H.-Eggers-Straße 22\n'
+              '24768 Rendsburg\n'
+              'Deutschland',
+            ),
+            const SizedBox(height: 16),
+            _heading('Vertreten durch'),
+            const Text(
+              'Volker Schenk (Vorstandsvorsitzender)\n'
+              'Ingo Vigneron (Stellvertreter)',
+            ),
+            const SizedBox(height: 16),
+            _heading('Kontakt'),
+            const Text(
+              'E-Mail: eikeapp@df-psnv.de\n'
+              'Telefon: +49 4331 7353705',
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                TextButton.icon(
+                  onPressed: () => _launchEmail('eikeapp@df-psnv.de'),
+                  icon: const Icon(Icons.email_outlined, size: 18),
+                  label: const Text('E-Mail schreiben'),
+                ),
+                TextButton.icon(
+                  onPressed: () => _launchTel('+49 4331 7353705'),
+                  icon: const Icon(Icons.phone_outlined, size: 18),
+                  label: const Text('Anrufen'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            _heading('Registereintrag'),
+            const Text(
+              // TODO: Anpassen
+              'Eingetragen im Vereinsregister\n'
+              'Registergericht: Amtsgericht Berlin\n'
+              'Registernummer: VR 30959 B',
+            ),
+            // Optional: Ggf. bei redaktionellen Inhalten erforderlich
+            // const SizedBox(height: 16),
+            // _heading('Inhaltlich verantwortlich (§ 18 Abs. 2 MStV)'),
+            // const Text(
+            //   // TODO: Anpassen
+            //   'Max Mustermann\n'
+            //   'Musterstraße 123\n'
+            //   '12345 Musterstadt',
+            // ),
+            const SizedBox(height: 32),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _heading(String text) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Text(
+        text,
+        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+}

--- a/lib/screens/privacy_screen.dart
+++ b/lib/screens/privacy_screen.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/material.dart';
+
+import '../widgets/app_header.dart';
+
+class PrivacyScreen extends StatelessWidget {
+  const PrivacyScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const AppHeader(title: 'Datenschutz'),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Gemäß Art. 13 DSGVO',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'Der Schutz Ihrer persönlichen Daten hat einen hohen Stellenwert. An dieser Stelle informieren wir Sie darüber, wie wir mit den Daten umgehen, die Nutzer wissentlich oder unwissentlich hinterlassen, wenn Sie die App verwenden.',
+            ),
+            _heading('Allgemeine Beschreibung'),
+            const Text(
+              'Die App "Eike" kann Feuerwehr-Einsatzkräften Informationen und Unterstützung bei der Vorbereitung und Verarbeitung von belastenden Einsätzen geben.',
+            ),
+            _heading(
+              'Verantwortlicher gem. Art. 4 Nr. 7 DSGVO und Behördlicher Datenschutzbeauftragter',
+            ),
+            const Text(
+              'Deutscher Fachverband für Psychosoziale Notfallversorgung (DF-PSNV) e.V.\n'
+              'P.-H.-Eggers-Straße 22\n'
+              '24768 Rendsburg\n'
+              'Deutschland',
+            ),
+            // const SizedBox(height: 16),
+            _heading('Datenverarbeitung in dieser App'),
+            _headingSmall('Grundsatz'),
+            const Text(
+              'Alle Daten werden lokal auf dem Gerät gespeichert.\n'
+              'Es findet in der aktuellen Implementierung keine Übertragung an Server/Cloud statt.'
+              'Biometrie wird nicht von der App gespeichert. Die App nutzt nur die vom Betriebssystem bereitgestellte Authentifizierung.',
+            ),
+            _headingSmall('Vorsätze'),
+            const Text(
+              'Beschreibung: Nutzende der App können eigene Verhaltensvorsätze in Textform in Freitextfelder schreiben. Die Angabe von Daten sind freiwillig.\n\n'
+              'Speicherung: Die angegebenen Daten werden ausschließlich auf dem Endgerät in einer verschlüsselten Datenbank gespeichert und nicht an Dritte oder weitere Systeme übertragen.\n\n'
+              'Veränderung: Die angebenen Daten können jederzeit durch den Nutzenden oder die Nutzende verändert werden.\n\n'
+              'Löschung: Die angegebenen Daten bleiben so lange auf dem Gerät gespeichert, bis:\n'
+              '• sie durch die Nutzende oder den Nutzenden geändert werden\n'
+              '• sie durch die Nutzende oder den Nutzenden alle Daten (Button in Einstellungen) gelöscht werden\n'
+              '• die App deinstalliert und hierdurch alle App-Daten gelöscht werden',
+            ),
+            _headingSmall('Welche Speicherorte nutzen wir wofür?'),
+            const Text(
+              'Wir verarbeiten und speichern Ihre Daten ausschließlich lokal auf Ihrem Endgerät. '
+              'Dabei setzen wir je nach Zweck unterschiedliche, geräteinterne Speicherbereiche ein. '
+              'Eine Übertragung an eigene Server oder in eine Cloud findet in der aktuellen Implementierung nicht statt.',
+            ),
+            _headingSmall('1) Verschlüsselte App-Datenbank'),
+            const Text(
+              'Zweck\n'
+              '• Speicherung der von Ihnen eingegebenen Inhalte\n\n'
+              'Welche Daten?\n'
+              '• Kontaktdaten eines Einsatznachsorgeteams (z. B. Teamname, Telefonnummer, E-Mail-Adresse)\n'
+              '• Persönliche Notizen/Freitexte zu den „7 Tipps“\n\n'
+              'Technische Umsetzung (Packages)\n'
+              '• Drift: https://pub.dev/packages/drift\n'
+              '• SQLCipher (Bibliotheken): https://pub.dev/packages/sqlcipher_flutter_libs\n'
+              '• SQLite3 (FFI): https://pub.dev/packages/sqlite3\n\n'
+              'Schutz und Zugriff\n'
+              '• Speicherung erfolgt verschlüsselt in einer lokalen Datenbank (SQLCipher)\n'
+              '• Zugriff ausschließlich innerhalb der App',
+            ),
+            _headingSmall('2) Keychain/Keystore'),
+            const Text(
+              'Zweck\n'
+              '• Ablage von Sicherheits- und Konfigurationsdaten\n\n'
+              'Welche Daten?\n'
+              '• Technischer Schlüssel zur Entschlüsselung der lokalen Datenbank\n'
+              '• Einstellung, ob eine optionale App-Sperre aktiviert ist (ja/nein)\n\n'
+              'Technische Umsetzung (Package)\n'
+              '• flutter_secure_storage: https://pub.dev/packages/flutter_secure_storage\n\n'
+              'Hinweis\n'
+              '• Auf iOS können Keychain-Einträge eine Deinstallation ggf. überdauern; '
+              'die App setzt Konfigurationswerte beim ersten Start nach Neuinstallation auf Standardwerte zurück.',
+            ),
+            _headingSmall('3) Technischer Marker für Initialisierung'),
+            const Text(
+              'Zweck\n'
+              '• Technische Initialisierung (Erkennen des ersten Starts nach Installation)\n\n'
+              'Welche Daten?\n'
+              '• Ein einfacher Marker/Schalter (keine Inhaltsdaten, keine Notizen, keine Kontaktdaten)\n\n'
+              'Technische Umsetzung (Package)\n'
+              '• shared_preferences: https://pub.dev/packages/shared_preferences',
+            ),
+            _headingSmall('4) Biometrische Authentifizierung'),
+            const Text(
+              'Zweck\n'
+              '• Entsperren der App über die vom Betriebssystem bereitgestellte Authentifizierung\n\n'
+              'Technische Umsetzung (Package)\n'
+              '• local_auth: https://pub.dev/packages/local_auth\n\n'
+              'Wichtig\n'
+              '• Die App erhebt oder speichert keine biometrischen Daten (z. B. Face ID/Fingerprint)\n'
+              '• Die biometrische Verarbeitung erfolgt ausschließlich im Betriebssystem innerhalb der jeweiligen Sicherheitsumgebung',
+            ),
+            _heading('Löschkonzept'),
+            const Text(
+              'In der App gibt es “Alle Daten löschen”: entfernt die in Drift gespeicherten Inhalte (Kontaktdaten + Tipps/Notizen).\n\n'
+              'Bei Deinstallation werden DB-Dateien in der App-Sandbox entfernt. Secure-Storage Einträge können auf iOS ggf. bestehen bleiben (wird durch First-run Reset auf Default zurückgeführt).',
+            ),
+            _headingSmall('Kontaktdaten eines PSNV-Teams'),
+            const Text(
+              'Beschreibung: Nutzende der App können Kontaktdaten zu ihrem zuständigen PSNV-Team eintragen, um die Kontaktdaten im Bedarfsfall angezeigt zu bekommen oder die Kontaktdaten an betriebssystemeigene Funktionen (Intents auf Telefon oder E-Mail) weitergeleitet zu bekommen. Die Angabe von Daten sind freiwillig.\n\n'
+              'Speicherung: Die angegebenen Daten werden ausschließlich auf dem Endgerät in einer verschlüsselten Datenbank gespeichert und nicht an Dritte oder weitere Systeme übertragen.\n\n'
+              'Veränderung: Die angebenen Daten können jederzeit durch den Nutzenden oder die Nutzende verändert werden.\n\n'
+              'Löschung: Die angegebenen Daten bleiben so lange auf dem Gerät gespeichert, bis:\n'
+              '• sie durch die Nutzende oder den Nutzenden geändert werden\n'
+              '• sie durch die Nutzende oder den Nutzenden alle Daten (Button in Einstellungen) gelöscht werden\n'
+              '• die App deinstalliert und hierdurch alle App-Daten gelöscht werden',
+            ),
+            _headingSmall('App-Einstellungen'),
+            const Text(
+              'Beschreibung: Nutzende der App können Einstellungen der App verändern, um sie nach ihren Wünschen und den gegebenen technischen Einstellungsmöglichkeiten anzupassen. Die Angabe von Daten sind freiwillig.\n\n'
+              'Speicherung: Die angegebenen Daten werden ausschließlich auf dem Endgerät gespeichert und nicht an Dritte oder weitere Systeme übertragen.\n\n'
+              'Veränderung: Die angebenen Daten können jederzeit durch den Nutzenden oder die Nutzende verändert werden.\n\n'
+              'Löschung: Die angegebenen Daten bleiben so lange auf dem Gerät gespeichert, bis:\n'
+              '• sie durch die Nutzende oder den Nutzenden geändert werden\n'
+              '• sie durch die Nutzende oder den Nutzenden alle Daten (Button in Einstellungen) gelöscht werden\n'
+              '• die App deinstalliert und hierdurch alle App-Daten gelöscht werden',
+            ),
+            _heading('Ihre Betroffenenrechte'),
+            const Text(
+              'Folgende Rechte stehen Ihnen als Betroffener gegenüber dem oben genannten Verantwortlichen zu:\n'
+              '• Recht auf Widerruf der Einwilligung nach Art. 7 Absatz 3 DSGVO\n'
+              '• Recht auf Auskunft nach Art. 15 DSGVO\n'
+              '• Recht auf Berichtigung nach Art. 16 DSGVO\n'
+              '• Recht auf Löschung nach Art. 17 DSGVO\n'
+              '• Recht auf Einschränkung der Verarbeitung nach Art. 18 DSGVO\n'
+              '• Recht auf Datenübertragbarkeit nach Art. 20 DSGVO\n'
+              '• Recht auf Widerspruch nach Art. 21 DSGVO\n'
+              '• Recht auf Beschwerde bei der Aufsichtsbehörde nach Art. 77 DSGVO, wenn Sie der Auffassung sind, dass die Verarbeitung Ihrer personenbezogenen Daten gegen Datenschutzbestimmungen verstößt.',
+            ),
+            _heading('Automatisierte Entscheidungsfindung und Profiling'),
+            const Text(
+              'Es findet keine automatisierte Entscheidungsfindung einschließlich Profiling gemäß Art. 22 Abs. 1 und 4 DSGVO statt.',
+            ),
+            _heading('Drittlandtransfer'),
+            const Text(
+              'Eine Übermittlung Ihrer Daten an ein Drittland oder eine internationale Organisation findet nicht statt und ist auch nicht geplant.',
+            ),
+            const SizedBox(height: 32),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _heading(String text) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 24, bottom: 8),
+      child: Text(
+        text,
+        style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+      ),
+    );
+  }
+
+  Widget _headingSmall(String text) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 20, bottom: 8),
+      child: Text(
+        text,
+        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -10,6 +10,8 @@ import '../security/local_auth_messages.dart';
 import '../widgets/app_header.dart';
 import '../widgets/section_title.dart';
 import '../widgets/button.dart';
+import 'privacy_screen.dart';
+import 'imprint_screen.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -313,6 +315,83 @@ class _SettingsScreenState extends State<SettingsScreen> {
                           textStyle: theme.textTheme.labelLarge?.copyWith(
                             fontWeight: FontWeight.w700,
                           ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SectionTitle('Rechtliches'),
+                _CardContainer(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Informationen zum Umgang mit deinen Daten.',
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                          height: 1.35,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: TextButton.icon(
+                          icon: const Icon(Icons.privacy_tip_outlined),
+                          label: const Text('Datenschutz'),
+                          onPressed: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (context) => const PrivacyScreen(),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                      const SizedBox(height: 20),
+                      Text(
+                        'Open-Source-Bibliotheken, die diese App ermöglichen.',
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                          height: 1.35,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: TextButton.icon(
+                          icon: const Icon(Icons.description_outlined),
+                          label: const Text('Lizenzen'),
+                          onPressed: () {
+                            showLicensePage(
+                              context: context,
+                              applicationName: 'EIKE',
+                            );
+                          },
+                        ),
+                      ),
+                      const SizedBox(height: 20),
+                      Text(
+                        'Angaben zum Anbieter und Kontaktmöglichkeiten.',
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                          height: 1.35,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: TextButton.icon(
+                          icon: const Icon(Icons.info_outline),
+                          label: const Text('Impressum'),
+                          onPressed: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (context) => const ImprintScreen(),
+                              ),
+                            );
+                          },
                         ),
                       ),
                     ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -511,7 +511,7 @@ packages:
       sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,6 +78,7 @@ flutter:
   assets:
     - assets/content/
     - assets/content/7-things/
+    - assets/fonts/Inter-license.txt
     - assets/images/
 
   # An image asset can refer to one or more resolution-specific "variants", see


### PR DESCRIPTION
Origin: https://github.com/EikeApp/eike-frontend/pull/66

# Pull-Request Template v1

> Beschreibung: Es wurde ein Datenschutzerklärungs Screen hinzugefügt.

## Screenshot / Videos

> Falls UI-Änderungen vorgenommen wurden

<img width="490" height="1052" alt="image" src="https://github.com/user-attachments/assets/ef366f5c-ab05-4ac6-a71b-8750685a7e3f" />

<img width="498" height="1053" alt="image" src="https://github.com/user-attachments/assets/0df263bd-7fdc-4521-a38e-9a24a8ea7951" />


## PR-Checkliste

- [x] Zugehörige Issues verlinken (rechts "Development")
- [x] keine Linter oder Build-Fehler
- [ ] Die Ende-zu-Ende Tests waren erfolgreich
- [x] Texte sind lesbar, Kontraste stimmen, Bedienelemente sind zugänglich - barrierefrei /barrierearm
- [ ] Die App zeigt verständliche Meldungen, wenn etwas funktioniert oder schiefgeht (z. B. „Passwort falsch“).
-> Es sind noch keine Tests integriert, ist ein View ohne Logik.
- [x] Dokumentation aktualisiert
-> Wüsste nicht wo sie aktualisiert werden müsste.
- [x] Wird in der Regel automatisch geprüft **aber**: Passwörter, Schlüssel oder Nutzerdaten tauchen nicht in Testausgaben oder im Quellcode auf
- [x] Der Autor hat die Commits gesquasht, um die Historie sauber zu halten

## Breaking Changes

- [ ] Gibt es Auswirkungen auf andere Komponenten?
- [ ] Muss etwas migriert oder angepasst werden?
-> In Zukunft muss der Datenschutz-Button in die Einstellungen View rein.