### PR TITLE
fixed naming of Kontakte Screen

### DIFF
--- a/packages/feat_contact/lib/presentation/contact_screen.dart
+++ b/packages/feat_contact/lib/presentation/contact_screen.dart
@@ -39,7 +39,7 @@ class _Scaffold extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: const EikeAppBar(title: 'Kontakt'),
+      appBar: const EikeAppBar(title: 'Kontakte'),
       body: ListView(
         padding: EikeTheme.pagePadding,
         children: [


### PR DESCRIPTION
# Pull-Request Template v1

> Beschreibung: 'Kontakt' geändert zu 'Kontakte' auf dem Kontakte Screen

## PR-Checkliste

- [ ] Zugehörige Issues verlinken (rechts "Development")
- [x] keine Linter oder Build-Fehler
- [x] Die Ende-zu-Ende Tests waren erfolgreich
- [x] Texte sind lesbar, Kontraste stimmen, Bedienelemente sind zugänglich - barrierefrei /barrierearm
- [x] Die App zeigt verständliche Meldungen, wenn etwas funktioniert oder schiefgeht (z. B. „Passwort falsch“).
- [x] Dokumentation aktualisiert
- [x] Wird in der Regel automatisch geprüft **aber**: Passwörter, Schlüssel oder Nutzerdaten tauchen nicht in Testausgaben oder im Quellcode auf
- [ ] Der Autor hat die Commits gesquasht, um die Historie sauber zu halten

## Breaking Changes

- [ ] Gibt es Auswirkungen auf andere Komponenten?
- [ ] Muss etwas migriert oder angepasst werden?
